### PR TITLE
(SERVER-66) Create dujour version check library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# version-check-service
+
+This library allows you to perform version checks with dujour. To use this in your project,
+add the following to your `project.clj` file:
+
+```
+[puppetlabs/dujour-version-check "0.1.0"]
+
+```
+
+Then, call the `version-check` function. This function takes two arguments,
+`product-name` and `update-server-url`. `update-server-url` should be a string
+containing the URL of the update server. `product-name` can either be a string
+containing the artifact-id or a map with the following schema:
+
+```clj
+{:group-id schema/Str
+ :artifact-id schema/Str}
+```
+
+If only the artifact id is provided, the group id will default to
+`"puppetlabs.packages"`.
+
+## License
+
+Copyright © 2014 Puppet Labs
+
+Distributed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html)

--- a/dev-resources/bootstrap.cfg
+++ b/dev-resources/bootstrap.cfg
@@ -1,0 +1,4 @@
+puppetlabs.services.version.version-check-service-web-service/hello-web-service
+puppetlabs.services.version.version-check-service-service/hello-service
+puppetlabs.trapperkeeper.services.webserver.jetty9-service/jetty9-service
+puppetlabs.trapperkeeper.services.webrouting.webrouting-service/webrouting-service

--- a/dev-resources/config.conf
+++ b/dev-resources/config.conf
@@ -1,0 +1,12 @@
+global {
+    logging-config = ./dev-resources/logback-dev.xml
+}
+
+webserver {
+    host = localhost
+    port = 8080
+}
+
+web-router-service: {
+    "puppetlabs.services.version.version-check-service-web-service/hello-web-service": "/hello"
+}

--- a/dev-resources/logback-dev.xml
+++ b/dev-resources/logback-dev.xml
@@ -1,0 +1,14 @@
+<configuration scan="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.eclipse.jetty.server" level="warn"/>
+    <logger name="org.eclipse.jetty.util.log" level="warn"/>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/dev-resources/logback-test.xml
+++ b/dev-resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration scan="true">
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %-5p [%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="error">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/project.clj
+++ b/project.clj
@@ -1,0 +1,28 @@
+(def ks-version "1.0.0")
+(def tk-version "1.0.0")
+(def tk-jetty-version "1.0.0")
+
+(defproject puppetlabs/dujour-version-check "0.1.0-SNAPSHOT"
+  :description "Dujour Version Check library"
+
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [org.clojure/tools.logging "0.3.1"]
+                 [puppetlabs/trapperkeeper ~tk-version]
+                 [prismatic/schema "0.2.2"]
+                 [puppetlabs/http-client "0.4.0"]
+                 [ring/ring-codec "1.0.0"]
+                 [cheshire "5.3.1"]
+                 [trptcolin/versioneer "0.1.0"]
+                 [slingshot "0.10.3"]]
+
+  :profiles {:dev {:dependencies [[puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
+                                  [puppetlabs/kitchensink ~ks-version :classifier "test" :scope "test"]
+                                  [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
+                                  [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version :classifier "test"]
+                                  [ring-mock "0.1.5"]]}}
+
+  :aliases {"tk" ["trampoline" "run" "--config" "dev-resources/config.conf"]}
+
+  :main puppetlabs.trapperkeeper.main
+
+  )

--- a/src/puppetlabs/dujour/version_check.clj
+++ b/src/puppetlabs/dujour/version_check.clj
@@ -1,0 +1,115 @@
+(ns puppetlabs.dujour.version-check
+  (:require [clojure.tools.logging :as log]
+            [schema.core :as schema]
+            [ring.util.codec :as ring-codec]
+            [puppetlabs.http.client.sync :as client]
+            [cheshire.core :as json]
+            [trptcolin.versioneer.core :as version]
+            [slingshot.slingshot :as sling]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Constants
+
+(def default-group-id "puppetlabs.packages")
+(def default-update-server-url "http://updates.puppetlabs.com")
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Schemas
+
+(def ProductCoords
+  {:group-id schema/Str
+   :artifact-id schema/Str})
+
+(def ProductName
+  (schema/conditional
+    #(string? %) schema/Str
+    #(map? %) ProductCoords))
+
+(def UpdateInfo
+  {:version schema/Str
+   :newer   schema/Bool
+   :link    schema/Str
+   :product schema/Str
+   (schema/optional-key :message) schema/Str})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Private
+
+(defn schema-match?
+  [schema obj]
+  (nil? (schema/check schema obj)))
+
+(schema/defn get-coords :- ProductCoords
+  [product-name :- ProductName]
+  (condp schema-match? product-name
+    schema/Str {:group-id default-group-id
+                :artifact-id product-name}
+    ProductCoords product-name))
+
+(schema/defn version*
+  "Get the version number of this installation."
+  [group-id artifact-id]
+  {:post [(string? %)]}
+  (version/get-version group-id artifact-id))
+
+(def version
+  "Get the version number of this installation."
+  (memoize version*))
+
+(schema/defn ^:always-validate update-info :- (schema/maybe UpdateInfo)
+  "Make a request to the puppetlabs server to determine the latest available
+  version. Returns the JSON object received from the server, which
+  is expected to be a map containing keys `:version`, `:newer`, and `:link`.
+  Returns `nil` if the request does not succeed for some reason."
+  [product-name :- ProductName
+   update-server-url :- schema/Str]
+  (let [{:keys [group-id artifact-id]} (get-coords product-name)
+        current-version (version group-id artifact-id)
+        version-data {:version current-version}
+        query-string (ring-codec/form-encode version-data)
+        url (format "%s?product=%s&group=%s&%s" update-server-url artifact-id group-id query-string)
+        {:keys [status body] :as resp} (client/get url
+                                                   {:headers {"Accept" "application/json"}
+                                                    :as :text})]
+    (if (= status 200)
+      (json/parse-string body true)
+      (sling/throw+ {:type ::update-request-failed
+                     :message resp}))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Public
+
+(defn validate-config!
+  [product-name update-server-url]
+  ;; if this ends up surfacing error messages that aren't very user-friendly,
+  ;; we can improve the validation logic.
+  (schema/validate ProductName product-name)
+  (schema/validate (schema/maybe schema/Str) update-server-url))
+
+(defn check-for-updates
+  "This will fetch the latest version number and log if the system
+  is out of date."
+  [product-name update-server-url]
+  (log/debugf "Checking for newer versions of %s" product-name)
+  (let [update-server-url             (or update-server-url default-update-server-url)
+        {:keys [version newer link]}  (try
+                                        (update-info product-name update-server-url)
+                                        (catch Throwable e
+                                          (log/debug e (format "Could not retrieve update information (%s)" update-server-url))))
+        link-str (if link
+                   (format " Visit %s for details." link)
+                   "")
+        update-msg (format "Newer version %s is available!%s" version link-str)]
+    (when newer
+      (log/info update-msg))))
+
+(defn version-check
+  [product-name update-server-url]
+  (validate-config! product-name update-server-url)
+  (future
+    (try
+      (check-for-updates product-name update-server-url)
+      (catch Exception e
+        (log/warn e "Error occurred while checking for updates")
+        (throw e)))))
+

--- a/test/puppetlabs/dujour/version_check_test.clj
+++ b/test/puppetlabs/dujour/version_check_test.clj
@@ -1,0 +1,61 @@
+(ns puppetlabs.dujour.version-check-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.trapperkeeper.testutils.webserver :as jetty9]
+            [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]
+            [puppetlabs.dujour.version-check :refer :all]
+            [schema.test :as schema-test]
+            [cheshire.core :as json]))
+
+(use-fixtures :once schema-test/validate-schemas)
+
+(deftest test-get-coords
+  (testing "group-id should use the default if not specified"
+    (is (= {:group-id    "puppetlabs.packages"
+            :artifact-id "foo"}
+           (get-coords "foo"))))
+  (testing "should use group-id if specified"
+    (is (= {:group-id    "foo.foo"
+            :artifact-id "foo"}
+           (get-coords {:group-id "foo.foo"
+                        :artifact-id "foo"})))))
+
+(defn update-available-app
+  [req]
+  {:status 200
+   :body (json/generate-string {:newer true
+                                :link "http://foo.com"
+                                :message "Howdy!"
+                                :product "foo"
+                                :version "9000.0.0"})})
+
+(defn server-error-app
+  [req]
+  {:status 500
+   :body "aaaaaaaaaaaaaaaaaaaaaaaaaa"})
+
+(deftest test-check-for-updates
+  (with-test-logging
+    (jetty9/with-test-webserver update-available-app port
+                                (check-for-updates "foo" (format "http://localhost:%s" port))
+                                (is (logged? #"Newer version 9000.0.0 is available!" :info))))
+  (with-test-logging
+    (jetty9/with-test-webserver server-error-app port
+                                (check-for-updates "foo" (format "http://localhost:%s" port))
+                                (is (logged? #"Could not retrieve update information" :debug)))))
+
+(deftest test-version-check
+  (with-test-logging
+    (jetty9/with-test-webserver update-available-app port
+                                (version-check "foo" (format "http://localhost:%s" port))
+                                (Thread/sleep 1000)
+                                (is (logged? #"Newer version 9000.0.0 is available!" :info))))
+  (with-test-logging
+    (jetty9/with-test-webserver server-error-app port
+                                (version-check "foo" (format "http://localhost:%s" port))
+                                (Thread/sleep 100)
+                                (is (logged? #"Could not retrieve update information" :debug)))))
+
+
+
+
+


### PR DESCRIPTION
Move the dujour version check service in Puppet Server into its
own library that is not a TK service.
