### PR TITLE
(MAINT) Add get-version-string function

### DIFF
--- a/src/puppetlabs/dujour/version_check.clj
+++ b/src/puppetlabs/dujour/version_check.clj
@@ -123,3 +123,8 @@
           (callback-fn server-response))))
     nil))
 
+(defn get-version-string
+  ([product-name]
+    (get-version-string product-name default-group-id))
+  ([product-name group-id]
+    (version group-id product-name)))

--- a/test/puppetlabs/dujour/version_check_test.clj
+++ b/test/puppetlabs/dujour/version_check_test.clj
@@ -65,7 +65,16 @@
                             (deliver return-val resp))]
           (check-for-updates! {:product-name "foo"} (format "http://localhost:%s" port) callback-fn)
           (is (nil? @return-val))
-          (is (logged? #"Could not retrieve update information" :debug))) ()))))
+          (is (logged? #"Could not retrieve update information" :debug)))))))
+
+(deftest test-get-version-string
+  (testing "get-version-string returns the correct version string"
+    (with-test-logging
+      (jetty9/with-test-webserver
+        update-available-app port
+        (let [version-string (get-version-string "trapperkeeper-webserver-jetty9" "puppetlabs")]
+          (is (not (.isEmpty version-string)))
+          (is (re-matches #"^\d+.\d+.\d+" version-string)))))))
 
 
 


### PR DESCRIPTION
Add a new public function, get-version-string, which returns the
version of a given product as a string.

This is required for the resolution of (SERVER-303)[https://tickets.puppetlabs.com/browse/SERVER-303], since  this function exists in `version-check-core` in Puppet Server but not in this library.