### PR TITLE
(maint) Allow arbitrary params in request-values

### DIFF
--- a/src/puppetlabs/dujour/version_check.clj
+++ b/src/puppetlabs/dujour/version_check.clj
@@ -26,7 +26,8 @@
     map?    ProductCoords))
 
 (def RequestValues
-  {:product-name ProductName})
+  {:product-name ProductName
+   schema/Any schema/Any})
 
 (def UpdateInfo
   {:version schema/Str
@@ -69,7 +70,10 @@
         {:keys [group-id artifact-id]} (get-coords product-name)
         current-version (version group-id artifact-id)
         version-data {:version current-version}
-        query-string (ring-codec/form-encode version-data)
+        query-string (-> request-values
+                         (dissoc :product-name)
+                         (merge version-data)
+                         ring-codec/form-encode)
         url (format "%s?product=%s&group=%s&%s" update-server-url artifact-id group-id query-string)
         {:keys [status body] :as resp} (client/get url
                                                    {:headers {"Accept" "application/json"}

--- a/test/puppetlabs/dujour/version_check_test.clj
+++ b/test/puppetlabs/dujour/version_check_test.clj
@@ -57,6 +57,19 @@
           (is (:version @return-val) "9000.0.0")
           (is (:newer @return-val))
           (is (logged? #"Newer version 9000.0.0 is available!" :info))))))
+  (testing "accepts arbitrary parameters in the request-values map"
+    (with-test-logging
+      (jetty9/with-test-webserver
+        update-available-app port
+        (let [return-val  (promise)
+              callback-fn (fn [resp]
+                            (deliver return-val resp))]
+          (check-for-updates! {:product-name "foo"
+                               :database-version "9.4"}
+                              (format "http://localhost:%s" port) callback-fn)
+          (is (:version @return-val) "9000.0.0")
+          (is (:newer @return-val))
+          (is (logged? #"Newer version 9000.0.0 is available!" :info))))))
   (testing "logs the correct message during an invalid version-check"
     (with-test-logging
       (jetty9/with-test-webserver server-error-app port


### PR DESCRIPTION
Prior to this commit `check-for-updates!` only accepted `:product-name`
as a request-value parameter but for projects like PuppetDB, we also
need to pass the database-version etc. to dujour. Since dujour itself
accepts arbitrary params in the query-string, this commit changes the
request-values you can pass to `check-for-updates!` to be arbitrary.