### PR TITLE
(RE-4929) Add CONTRIBUTING.md and update README with Support section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# How to contribute
+
+Third-party patches are essential for keeping Puppet Labs open-source projects
+great. We want to keep it as easy as possible to contribute changes that
+allow you to get the most out of our projects. There are a few guidelines
+that we need contributors to follow so that we can have a chance of keeping on
+top of things.  For more info, see our canonical guide to contributing:
+
+[https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md](https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -34,3 +34,26 @@ desired artifact as a string.
 Copyright © 2014 Puppet Labs
 
 Distributed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html)
+
+Support
+-------
+
+Please log tickets and issues at our [JIRA
+tracker](http://tickets.puppetlabs.com).  A [mailing
+list](https://groups.google.com/forum/?fromgroups#!forum/puppet-users) is
+available for asking questions and getting help from others. In addition there
+is an active #puppet channel on Freenode.
+
+We use semantic version numbers for our releases, and recommend that users stay
+as up-to-date as possible by upgrading to patch releases and minor releases as
+they become available.
+
+Bugfixes and ongoing development will occur in minor releases for the current
+major version. Security fixes will be backported to a previous major version on
+a best-effort basis, until the previous major version is no longer maintained.
+
+Long-term support, including security patches and bug fixes, is available for
+commercial customers. Please see the following page for more details:
+
+[Puppet Enterprise Support
+Lifecycle](http://puppetlabs.com/misc/puppet-enterprise-lifecycle)


### PR DESCRIPTION
This patch addresses the problems mentioned in RE-4929 where the project is not
in line with our release process.  Specifically, the Support section was
missing and is added by this patch along with a copy of the CONTRIBUTING.md
file from Trapperkeeper.