### PR TITLE
(PE-16742) Send hash of certname as unique identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ containing the artifact-id or a map with the following schema:
 If only the artifact id is provided, the group id will default to
 `"puppetlabs.packages"`.
 
+The request map can also accept a `:certname` string, which can be used
+to uniquely identify a user. This value will be SHA-512 hashed before
+being sent to the server.
+
 This library provides one other public API function, `get-version-string`. This function
 takes one argument, `product-name`, which should be the artifact id as a string. It
 optionally takes one more argument, `group-id`, which should be the group-id of the

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ containing the artifact-id or a map with the following schema:
 If only the artifact id is provided, the group id will default to
 `"puppetlabs.packages"`.
 
-The request map can also accept a `:certname` string, which can be used
-to uniquely identify a user. This value will be SHA-512 hashed before
-being sent to the server.
+The request map can also accept `:certname` and `:cacert` strings, which
+can be used to uniquely identify a user. These values will be SHA-512
+hashed and sent as `site-id` and `host-id`, respectively, before being
+sent to the server.
 
 This library provides one other public API function, `get-version-string`. This function
 takes one argument, `product-name`, which should be the artifact id as a string. It


### PR DESCRIPTION
In order for us to match user data over time, we need some unique identifiers.
For this, we will be SHA-512 hashing the certname and cacert of the puppetserver
and sending that in the request to dujour.