### PR TITLE
(PE-17051) Send agent OS to dujour

### DIFF
--- a/src/puppetlabs/dujour/version_check.clj
+++ b/src/puppetlabs/dujour/version_check.clj
@@ -81,6 +81,7 @@
         version-data {:version current-version}
         request-body (-> request-values
                          (dissoc :product-name)
+                         (set/rename-keys {:agent-os :agent_os})
                          (assoc "product" artifact-id)
                          (assoc "group" group-id)
                          (merge version-data)


### PR DESCRIPTION
"agent-os" is a new property which needs to be mutated to be
"agent_os" before sending to dujour.