### PR TITLE
(PE-15719) Send puppet agent versions to dujour

### DIFF
--- a/src/puppetlabs/dujour/version_check.clj
+++ b/src/puppetlabs/dujour/version_check.clj
@@ -81,7 +81,8 @@
         version-data {:version current-version}
         request-body (-> request-values
                          (dissoc :product-name)
-                         (set/rename-keys {:agent-os :agent_os})
+                         (set/rename-keys {:agent-os :agent_os
+                                           :puppet-agent-versions :puppet_agent_versions})
                          (assoc "product" artifact-id)
                          (assoc "group" group-id)
                          (merge version-data)
@@ -163,7 +164,8 @@
                                 (log/warn e "Error occurred while checking for updates")
                                 (throw e)))]
         (if-not (nil? callback-fn)
-          (callback-fn server-response))))))
+          (callback-fn server-response)
+          server-response)))))
 
 (defn get-version-string
   ([product-name]

--- a/test/puppetlabs/dujour/version_check_test.clj
+++ b/test/puppetlabs/dujour/version_check_test.clj
@@ -136,6 +136,20 @@
           (is (= (message "agent_os") agent-os))
           (is (nil? (message "agent-os")))))))
 
+  (testing "sends puppet_agent_versions instead of puppet-agent-versions"
+    (with-test-logging
+      (jetty9/with-test-webserver return-all-as-message-app port
+        (let [return-val (promise)
+              callback-fn (fn [resp] (deliver return-val resp))
+              puppet-agent-versions {"1.6.7" 15 "1.4.5" 5}
+              _ (check-for-updates! {:puppet-agent-versions puppet-agent-versions
+                                     :product-name     "foo"
+                                     :database-version "9.4"}
+                                    (format "http://localhost:%s" port) callback-fn)
+              message (json/parse-string (:message @return-val))]
+          (is (= (message "puppet_agent_versions") puppet-agent-versions))
+          (is (nil? (message "puppet-agent-versions")))))))
+
   (testing "doesn't clobber agent_os"
     (with-test-logging
       (jetty9/with-test-webserver return-all-as-message-app port


### PR DESCRIPTION
"puppet-agent-versions" is a new property which needs to be mutated to be
"puppet_agent_versions" before sending to dujour.