### PR TITLE
Add internal_list key to MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2,22 +2,27 @@
   "version": 1,
   "file_format": "This MAINTAINERS file format is described at https://github.com/puppetlabs/maintainers",
   "issues": "https://tickets.puppetlabs.com/browse/PE",
+  "internal_list": "https://groups.google.com/a/puppet.com/forum/?hl=en#!forum/team-product-analytics",
   "people": [
     {
       "github": "briancain",
-      "email": "brian.cain@puppet.com"
+      "email": "brian.cain@puppet.com",
+      "name": "Brian Cain"
     },
     {
       "github": "smcclellan",
-      "email": "scott.mcclellan@puppet.com"
+      "email": "scott.mcclellan@puppet.com",
+      "name": "Scott McClellan"
     },
     {
       "github": "pcarlisle",
-      "email": "patrick@puppet.com"
+      "email": "patrick@puppet.com",
+      "name": "Patrick Carlisle"
     },
     {
       "github": "vine77",
-      "email": "nathan.ward@puppet.com"
+      "email": "nathan.ward@puppet.com",
+      "name": "Nathan Ward"
     }
   ]
 }


### PR DESCRIPTION
This change adds a reference to the Google group the maintainers are associated with and adds name values to the maintainers.