### PR TITLE
(PE-17701) Separate update check from telemetry

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
 (defproject puppetlabs/dujour-version-check "0.1.9-SNAPSHOT"
   :description "Dujour Version Check library"
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [prismatic/schema "0.2.2"]
                  [puppetlabs/http-client "0.4.4"]


### PR DESCRIPTION
This deprecates `check-for-updates!` and replaces it with two new
functions, `send-telemetry` and `check-for-update`, to allow sending
telemetry data without reporting on version updates, and check for
version updates without sending any telemetry data. The
`check-for-update` function filters out any parameters that are
unnecessary for a version check.

This also attempts to improve the error handling and logging.