### PR TITLE
Allow whitelist in dujour response

### DIFF
--- a/src/puppetlabs/dujour/version_check.clj
+++ b/src/puppetlabs/dujour/version_check.clj
@@ -40,7 +40,8 @@
    :newer schema/Bool
    :link schema/Str
    :product schema/Str
-   (schema/optional-key :message) schema/Str})
+   (schema/optional-key :message) schema/Str
+   (schema/optional-key :whitelist) {schema/Keyword {schema/Keyword schema/Str}}})
 
 (def RequestResult
   {:status schema/Int
@@ -121,7 +122,7 @@
     (let [update-response (json/parse-string body true)]
       (if (schema/check (merge UpdateInfo {schema/Any schema/Any}) update-response)
         (throw-unexpected-response body)
-        (select-keys update-response [:version :newer :link :product :message])))
+        (select-keys update-response [:version :newer :link :product :message :whitelist])))
     (catch JsonParseException _
       (throw-unexpected-response body))))
 

--- a/test/puppetlabs/dujour/version_check_test.clj
+++ b/test/puppetlabs/dujour/version_check_test.clj
@@ -40,7 +40,8 @@
                                   :link "http://foo.com"
                                   :message (json/generate-string params)
                                   :product "foo"
-                                  :version "9000.0.0"})}))
+                                  :version "9000.0.0"
+                                  :whitelist {"namespace.name" {:datatype "string", :description "something"}}})}))
 
 (defn server-error-app
   [_]
@@ -70,6 +71,7 @@
                        :message "woooo"
                        :product "zombocom"
                        :version "1000000"
+                       :whitelist {"namespace.name" {:datatype "string", :description "something"}}
                        :you "can"
                        :do "anything"
                        :at "zombocom"})})
@@ -98,13 +100,14 @@
                                 (format "http://localhost:%s" port))]
           (is (= (:version return-val) "9000.0.0"))
           (is (= ((json/parse-string (:message return-val)) "database-version") nil))
+          (is (= (:whitelist return-val) {:namespace.name {:datatype "string", :description "something"}}))
           (is (:newer return-val))
           (is (logged? #"Newer version 9000.0.0 is available!" :info))))))
 
   (testing "allows but does not return extra response fields"
     (with-test-logging
       (jetty9/with-test-webserver extra-fields-app port
-        (is (= [:version :newer :link :product :message]
+        (is (= [:version :newer :link :product :message :whitelist]
                (keys (check-for-update {:certname "some-certname"
                                         :cacert "some-cacert"
                                         :product-name "foo"


### PR DESCRIPTION
This includes the whitelist key when received from dujour. That means
"whitelist" is added among "newer", "link", "message", "product", and
"version".