### PR TITLE
Use https, update dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject puppetlabs/dujour-version-check "0.2.4-SNAPSHOT"
+(defproject puppetlabs/dujour-version-check "0.3.0-SNAPSHOT"
   :description "Dujour Version Check library"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.2.4"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.9.4"]
                    :inherit [:managed-dependencies]}
 
-  :plugins [[lein-parent "0.3.7"]]
+  :plugins [[lein-parent "0.3.8"]]
 
   :dependencies [[org.clojure/clojure]
                  [org.clojure/tools.logging]

--- a/src/puppetlabs/dujour/version_check.clj
+++ b/src/puppetlabs/dujour/version_check.clj
@@ -15,7 +15,7 @@
 ;;; Constants
 
 (def default-group-id "puppetlabs.packages")
-(def default-update-server-url "http://updates.puppetlabs.com")
+(def default-update-server-url "https://updates.puppetlabs.com")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schemas


### PR DESCRIPTION
updates.puppet.com now requires TLS, so update the URL to https://updates.puppet.com/ to avoid the redirect.

Updates dependencies to latest versions.