### PR TITLE
Update to puppet.com

### DIFF
--- a/src/puppetlabs/dujour/version_check.clj
+++ b/src/puppetlabs/dujour/version_check.clj
@@ -15,7 +15,7 @@
 ;;; Constants
 
 (def default-group-id "puppetlabs.packages")
-(def default-update-server-url "https://updates.puppetlabs.com")
+(def default-update-server-url "https://updates.puppet.com")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schemas


### PR DESCRIPTION
Actually updates the URL to use puppet.com.