### PR TITLE
(maint) update to clj-parent 5.2.6, prepare for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: 2.9.1
+lein: 2.9.10
 jdk:
 - openjdk8
 - openjdk11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.0
+  * update to clj-parent 5.2.6, which includes support for the new bouncycastle `18on` naming of the library from `15on`. 
+
 ## 0.1.3
   * Allow arbitrary parameters to be included in the `request-values` map,
     rather than just `:product-name`

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
-(defproject puppetlabs/dujour-version-check "0.3.2-SNAPSHOT"
+(defproject puppetlabs/dujour-version-check "1.0.0-SNAPSHOT"
   :description "Dujour Version Check library"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.11.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "5.2.6"]
                    :inherit [:managed-dependencies]}
 
   :plugins [[lein-parent "0.3.8"]]
@@ -23,12 +23,13 @@
                                      :password :env/clojars_jenkins_password
                                      :sign-releases false}]]
 
-  :profiles {:defaults {:dependencies [[puppetlabs/trapperkeeper :classifier "test" :scope "test"]
+  :profiles {:provided {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]}
+             :defaults {:dependencies [[puppetlabs/trapperkeeper :classifier "test" :scope "test"]
                                        [puppetlabs/kitchensink :classifier "test" :scope "test"]
                                        [puppetlabs/trapperkeeper-webserver-jetty9]
                                        [puppetlabs/trapperkeeper-webserver-jetty9 :classifier "test"]
                                        [ring-mock "0.1.5"]]}
-             :dev [:defaults {:dependencies [[org.bouncycastle/bcpkix-jdk15on]]}]
+             :dev [:defaults {:dependencies [[org.bouncycastle/bcpkix-jdk18on]]}]
              :fips [:defaults {:dependencies [[org.bouncycastle/bctls-fips]
                                               [org.bouncycastle/bcpkix-fips]
                                               [org.bouncycastle/bc-fips]]
@@ -42,5 +43,5 @@
                                                   ["-Djava.security.properties==./dev-resources/java.security.jdk8-fips"]
                                                   (throw unsupported-ex))
                                               11 ["-Djava.security.properties==./dev-resources/java.security.jdk11-fips"]
-                                              (throw unsupported-ex)))}]}
-  )
+                                              (throw unsupported-ex)))}]})
+


### PR DESCRIPTION
This updates to clj-parent 5.2.6, changes the references from `15on` in bouncy-castle to `18on`.

Additionaly, it prepares for a 1.0.0 release.